### PR TITLE
Integrate PgTyped example

### DIFF
--- a/.pgtyped.json
+++ b/.pgtyped.json
@@ -1,0 +1,13 @@
+{
+  "db": {
+    "host": "${DB_HOST}",
+    "port": "${DB_PORT}",
+    "database": "${DB_NAME}",
+    "user": "${DB_USER}",
+    "password": "${DB_PASSWORD}"
+  },
+  "srcDir": "api/src/sql",
+  "glob": "**/*.sql",
+  "prettier": true,
+  "failOnError": true
+}

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ python -m venv .venv
 .venv\Scripts\Activate.ps1  # For Windows PowerShell
 # For Bash/Linux/Mac: source .venv/bin/activate
 python -m pip install --upgrade pip
-pip install -r requirements.txt
+ pip install -r requirements.txt
 ```
 
 6. **Claude for Desktop configuration**
@@ -171,6 +171,15 @@ Edit Claude for Desktop configuration file `claude_desktop_config.json`:
   }
 }
 ```
+
+7. **Generate SQL types**
+
+Run PgTyped to generate TypeScript types from SQL files:
+
+```bash
+npm run gen:types
+```
+
 
 **Note**: Replace `project-directory-path` with your actual project path. For Windows, backslashes in paths need to be escaped. Example: `C:\\Users\\username\\projects\\ticket-system`
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -172,6 +172,15 @@ Claude for Desktopの設定ファイル`claude_desktop_config.json`を編集：
 }
 ```
 
+7. **SQL型生成**
+
+PgTypedを使ってSQLファイルからTypeScript型を生成します:
+
+```bash
+npm run gen:types
+```
+
+
 **注意**: `プロジェクトディレクトリパス`は実際のプロジェクトパスに置き換えてください。Windowsの場合はパスのバックスラッシュをエスケープする必要があります。例: `C:\\Users\\username\\projects\\ticket-system`
 
 ### データのリセット

--- a/api/package.json
+++ b/api/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "build": "tsc",
     "start": "node build/src/index.js",
-    "dev": "concurrently \"npm run build:watch\" \"npm run start:watch\"",
+    "dev": "concurrently \"npm run build:watch\" \"npm run start:watch\" \"pgtyped -w\"",
     "build:watch": "tsc --watch",
     "start:watch": "nodemon --watch build/ --exec \"npm run start\"",
     "lint": "eslint 'src/**/*.ts'",
-    "test": "jest"
+    "test": "jest",
+    "gen:types": "pgtyped -c"
   },
   "dependencies": {
     "@google-cloud/functions-framework": "^3.3.0",
@@ -32,6 +33,7 @@
     "jest": "^29.7.0",
     "nodemon": "^3.0.1",
     "ts-jest": "^29.1.1",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "pgtyped": "^1.3.0"
   }
 }

--- a/api/src/controllers/ticketController.ts
+++ b/api/src/controllers/ticketController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express';
 import { logger } from '../utils/logger';
 import { TicketQueryParams, ChangedField } from '../types';
+import { fetchUsers } from '../repos/userRepo';
 
 /**
  * Get ticket list with filtering and pagination
@@ -755,32 +756,14 @@ export const getTicketHistory = async (req: Request, res: Response) => {
 /**
  * Get users list
  */
+
 export const getUsersList = async (req: Request, res: Response) => {
   try {
-    const client = await req.db.connect();
-    try {
-      const query = `
-        SELECT id, name, email, role
-        FROM mcp_ux.users
-        ORDER BY name ASC
-      `;
-      
-      const result = await client.query(query);
-      
-      const users = result.rows.map(row => ({
-        id: row.id,
-        name: row.name,
-        email: row.email,
-        role: row.role
-      }));
-      
-      res.json(users);
-    } finally {
-      client.release();
-    }
+    const users = await fetchUsers(req.db);
+    res.json(users);
   } catch (error) {
-    logger.error('Error getting users list', { 
-      error: error instanceof Error ? error.message : String(error) 
+    logger.error('Error getting users list', {
+      error: error instanceof Error ? error.message : String(error)
     });
     res.status(500).json({ error: 'An error occurred while retrieving users' });
   }

--- a/api/src/repos/userRepo.ts
+++ b/api/src/repos/userRepo.ts
@@ -1,0 +1,6 @@
+import { Pool } from 'pg';
+import { IGetUsersResult, getUsers } from '../sql/users/selectAll';
+
+export const fetchUsers = async (db: Pool): Promise<IGetUsersResult[]> => {
+  return getUsers.run(undefined, db);
+};

--- a/api/src/sql/users/selectAll.sql
+++ b/api/src/sql/users/selectAll.sql
@@ -1,0 +1,4 @@
+/* @name getUsers */
+SELECT id, name, email, role
+FROM mcp_ux.users
+ORDER BY name ASC;

--- a/api/src/sql/users/selectAll.ts
+++ b/api/src/sql/users/selectAll.ts
@@ -1,0 +1,18 @@
+import { Pool } from 'pg';
+
+export interface IGetUsersParams {}
+
+export interface IGetUsersResult {
+  id: string;
+  name: string;
+  email: string;
+  role: string;
+}
+
+export const getUsers = {
+  run: async (_params: IGetUsersParams | undefined, db: Pool): Promise<IGetUsersResult[]> => {
+    const query = `SELECT id, name, email, role FROM mcp_ux.users ORDER BY name ASC;`;
+    const result = await db.query<IGetUsersResult>(query);
+    return result.rows;
+  }
+};


### PR DESCRIPTION
## Summary
- set up pgtyped with config file
- add scripts to package.json and install pgtyped
- move user list SQL to external file and typed repo
- call typed repo from controller
- document new step for generating SQL types

## Testing
- `npm test` *(fails: jest not found)*